### PR TITLE
README.md: fix/improve prereq section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Tested on Linux and Mac OS X, should be working on BSD. You could be able to build and make it working with Cygwin on Windows.
 
 ## Prerequisites
-You might need to install devel packages for `libmagic`. On Debian, Ubuntu and CentOS, get `libmagic-dev` package from your package manager. On Mac OS X get `libmagic` via Homebrew: `brew install libmagic`. If you don't have the required dev packages, compilation will be terminated by an error saying `magic.h` cannot be found.
+This uses the `libmagic` library from the `file` tool, so you might need to install the development package for `libmagic`. On Debian or Ubuntu: `apt-get install libmagic-dev`. On RHEL, CentOS or Fedora: `yum install file-devel`. On Mac OS X: `brew install libmagic`. If you don't have the required package, compilation will be terminated by an error saying `magic.h` cannot be found.
 
 
 ## Usage


### PR DESCRIPTION
The changes are, in the order of importance:
1. On CentOS, the package name is `file-devel` not `libmagic-dev`.
2. As it was done for Mac OS X, add the actual commands to install needed package.
3. Add Fedora and RHEL next to CentOS.
4. Mention this comes from 'file' tool.
5. It's 'package' not 'packages'.