### PR TITLE
Fix test and Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+go:
+  - 1.4
+  - 1.5
+  - tip
+addons:
+  apt:
+    packages:
+      - libmagic-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,8 @@ addons:
   apt:
     packages:
       - libmagic-dev
+before_install:
+  - go get golang.org/x/tools/cmd/cover
+  - go get github.com/mattn/goveralls
+after_script:
+  - sh `pwd`/scripts/coverage --coveralls

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# magicmime [![Build Status](http://img.shields.io/travis/rakyll/magicmime/master.svg?style=flat)](https://travis-ci.org/rakyll/magicmime) [![GoDoc](https://godoc.org/github.com/rakyll/magicmime?status.svg)](https://godoc.org/github.com/rakyll/magicmime)
+# magicmime [![Build Status](http://img.shields.io/travis/rakyll/magicmime/master.svg?style=flat)](https://travis-ci.org/rakyll/magicmime) [![Coverage Status](https://coveralls.io/repos/rakyll/magicmime/badge.svg)](https://coveralls.io/r/rakyll/magicmime) [![GoDoc](https://godoc.org/github.com/rakyll/magicmime?status.svg)](https://godoc.org/github.com/rakyll/magicmime)
 
 `magicmime` is a Go package which allows you to discover a file's mimetype by looking for magic numbers in its content. It could be used as a supplementary for Go's [`mime`](http://golang.org/pkg/mime/) package which only interprets the file extension to detect mimetypes. Internally, it implements [libmagic(3)](http://linux.die.net/man/3/libmagic) bindings.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# magicmime
+# magicmime [![Build Status](http://img.shields.io/travis/rakyll/magicmime/master.svg?style=flat)](https://travis-ci.org/rakyll/magicmime) [![GoDoc](https://godoc.org/github.com/rakyll/magicmime?status.svg)](https://godoc.org/github.com/rakyll/magicmime)
 
 `magicmime` is a Go package which allows you to discover a file's mimetype by looking for magic numbers in its content. It could be used as a supplementary for Go's [`mime`](http://golang.org/pkg/mime/) package which only interprets the file extension to detect mimetypes. Internally, it implements [libmagic(3)](http://linux.die.net/man/3/libmagic) bindings.
 

--- a/example_test.go
+++ b/example_test.go
@@ -14,21 +14,19 @@
 
 // +build linux darwin
 
-package magicmime_test
+package magicmime
 
 import (
 	"log"
-
-	"github.com/rakyll/magicmime"
 )
 
 func Example_typeByFile() {
-	if err := magicmime.Open(magicmime.MAGIC_MIME_TYPE | magicmime.MAGIC_SYMLINK | magicmime.MAGIC_ERROR); err != nil {
+	if err := Open(MAGIC_MIME_TYPE | MAGIC_SYMLINK | MAGIC_ERROR); err != nil {
 		log.Fatal(err)
 	}
-	defer magicmime.Close()
+	defer Close()
 
-	mimetype, err := magicmime.TypeByFile("/path/to/file")
+	mimetype, err := TypeByFile("/path/to/file")
 	if err != nil {
 		log.Fatalf("error occured during type lookup: %v", err)
 	}

--- a/magicmime_test.go
+++ b/magicmime_test.go
@@ -18,6 +18,7 @@ package magicmime
 
 import (
 	"encoding/base64"
+	"strings"
 	"testing"
 )
 
@@ -94,9 +95,14 @@ func testFile(tb testing.TB, path string, expected string) {
 }
 
 func TestMissingFile(t *testing.T) {
+	if err := Open(MAGIC_MIME_TYPE | MAGIC_SYMLINK | MAGIC_ERROR); err != nil {
+		t.Fatal(err)
+	}
+	defer Close()
+
 	_, err := TypeByFile("missingFile.txt")
-	if err == nil {
-		t.Error("no error for missing file")
+	if err == nil || !strings.Contains(err.Error(), "No such file or directory") {
+		t.Errorf("Expected error for missing file, got %v", err)
 	}
 }
 

--- a/scripts/coverage
+++ b/scripts/coverage
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Generate test coverage statistics for Go packages.
+#
+# Works around the fact that `go test -coverprofile` currently does not work
+# with multiple packages, see https://code.google.com/p/go/issues/detail?id=6909
+#
+# Usage: script/coverage [--html|--coveralls]
+#
+#     --html      Additionally create HTML report and open it in browser
+#     --coveralls Push coverage statistics to coveralls.io
+#
+# Source: https://github.com/mlafeldt/chef-runner/blob/v0.7.0/script/coverage
+
+set -e
+
+workdir=.cover
+profile="$workdir/cover.out"
+mode=count
+
+generate_cover_data() {
+    rm -rf "$workdir"
+    mkdir "$workdir"
+
+    for pkg in "$@"; do
+        f="$workdir/$(echo $pkg | tr / -).cover"
+        go test -covermode="$mode" -coverprofile="$f" "$pkg"
+    done
+
+    echo "mode: $mode" >"$profile"
+    grep -h -v "^mode:" "$workdir"/*.cover >>"$profile"
+}
+
+show_cover_report() {
+    go tool cover -${1}="$profile"
+}
+
+push_to_coveralls() {
+    echo "Pushing coverage statistics to coveralls.io"
+    goveralls -coverprofile="$profile"
+}
+
+generate_cover_data $(go list ./...)
+show_cover_report func
+case "$1" in
+"")
+    ;;
+--html)
+    show_cover_report html ;;
+--coveralls)
+    push_to_coveralls ;;
+*)
+    echo >&2 "error: invalid option: $1"; exit 1 ;;
+esac


### PR DESCRIPTION
I solved the multiple definitions issue by changing the package of example_test.go to magicmime.

After that I noticed TestMissingFile started panicking on Travis and saw that the mimetype DB was not set up. Interestingly, on OS X and the Linux vm I have tested it on, it doesn't panic.

Maybe it should never panic and the version of Travis is outdated / panics, but I haven't had the time to verify it.

The last commit adds Coveralls to your project, if you want it. If you decide to do it, first you have to add your project on [Coveralls](https://coveralls.io/), then go to [rakyll/magicmime Travis' settings](https://travis-ci.org/rakyll/magicmime/settings) and add environment variable COVERALLS_REPO_TOKEN with the token value you got on Coveralls. If you don't, just don't merge it :)

This closes #17.