### PR TITLE
Support synchronized access by multiple goroutines

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func ExampleTypeByFile() {
-	if err := magicmime.Open(magicmime.MAGIC_MIME_TYPE | magicmime.MAGIC_SYMLINK | magicmime.MAGIC_ERROR); err != nil {
+	if err := magicmime.Open(magicmime.Unsynchronized, magicmime.MAGIC_MIME_TYPE|magicmime.MAGIC_SYMLINK|magicmime.MAGIC_ERROR); err != nil {
 		log.Fatal(err)
 	}
 	defer magicmime.Close()

--- a/example_test.go
+++ b/example_test.go
@@ -19,16 +19,17 @@ package magicmime_test
 import (
 	"log"
 
-	"github.com/rakyll/magicmime"
+	"github.com/skidder/magicmime"
 )
 
 func ExampleTypeByFile() {
-	if err := magicmime.Open(magicmime.Unsynchronized, magicmime.MAGIC_MIME_TYPE|magicmime.MAGIC_SYMLINK|magicmime.MAGIC_ERROR); err != nil {
+	db, err := magicmime.Open(magicmime.UNSYNCHRONIZED, magicmime.MAGIC_MIME_TYPE|magicmime.MAGIC_SYMLINK|magicmime.MAGIC_ERROR)
+	if err != nil {
 		log.Fatal(err)
 	}
-	defer magicmime.Close()
+	defer db.Close()
 
-	mimetype, err := magicmime.TypeByFile("/path/to/file")
+	mimetype, err := db.TypeByFile("/path/to/file")
 	if err != nil {
 		log.Fatalf("error occured during type lookup: %v", err)
 	}

--- a/magicmime.go
+++ b/magicmime.go
@@ -30,10 +30,21 @@ import "C"
 
 import (
 	"errors"
+	"sync"
 	"unsafe"
 )
 
-var db C.magic_t
+type MimeDB struct {
+	mutex *sync.Mutex
+	db    C.magic_t
+}
+
+type SyncMode int
+
+const (
+	Synchronized   SyncMode = iota
+	Unsynchronized SyncMode = iota
+)
 
 type Flag int
 
@@ -113,49 +124,68 @@ const (
 
 // Open initializes magicmime and opens the magicmime database
 // with the specified flags. Once successfully opened, users must
-// call Close when they are
-func Open(flags Flag) error {
-	db = C.magic_open(C.int(0))
+// call Close when they are finished. The syncMode parameter controls
+// whether access to the database is synchronized to allow use by
+// multiple goroutines. This is likely required for users of
+// libmagic since the library is not thread-safe.
+func Open(syncMode SyncMode, flags Flag) (*MimeDB, error) {
+	db := C.magic_open(C.int(0))
 	if db == nil {
-		return errors.New("error opening magic")
+		return nil, errors.New("error opening magic")
 	}
 
 	if code := C.magic_setflags(db, C.int(flags)); code != 0 {
-		Close()
-		return errors.New(C.GoString(C.magic_error(db)))
+		C.magic_close(db)
+		return nil, errors.New(C.GoString(C.magic_error(db)))
 	}
 
 	if code := C.magic_load(db, nil); code != 0 {
-		Close()
-		return errors.New(C.GoString(C.magic_error(db)))
+		C.magic_close(db)
+		return nil, errors.New(C.GoString(C.magic_error(db)))
 	}
-	return nil
+	var mutex *sync.Mutex
+	if syncMode == Synchronized {
+		mutex = &sync.Mutex{}
+	}
+	return &MimeDB{mutex, db}, nil
 }
 
 // TypeByFile looks up for a file's mimetype by its content.
 // It uses a magic number database which is described in magic(5).
-func TypeByFile(filePath string) (string, error) {
+func (m *MimeDB) TypeByFile(filePath string) (string, error) {
 	path := C.CString(filePath)
 	defer C.free(unsafe.Pointer(path))
-	out := C.magic_file(db, path)
+	if m.mutex != nil {
+		m.mutex.Lock()
+		defer m.mutex.Unlock()
+	}
+	out := C.magic_file(m.db, path)
 	if out == nil {
-		return "", errors.New(C.GoString(C.magic_error(db)))
+		return "", errors.New(C.GoString(C.magic_error(m.db)))
 	}
 	return C.GoString(out), nil
 }
 
 // TypeByBuffer looks up for a blob's mimetype by its contents.
 // It uses a magic number database which is described in magic(5).
-func TypeByBuffer(blob []byte) (string, error) {
+func (m *MimeDB) TypeByBuffer(blob []byte) (string, error) {
 	bytes := unsafe.Pointer(&blob[0])
-	out := C.magic_buffer(db, bytes, C.size_t(len(blob)))
+	if m.mutex != nil {
+		m.mutex.Lock()
+		m.mutex.Unlock()
+	}
+	out := C.magic_buffer(m.db, bytes, C.size_t(len(blob)))
 	if out == nil {
-		return "", errors.New(C.GoString(C.magic_error(db)))
+		return "", errors.New(C.GoString(C.magic_error(m.db)))
 	}
 	return C.GoString(out), nil
 }
 
-func Close() {
-	C.magic_close(db)
-	db = nil
+func (m *MimeDB) Close() {
+	if m.mutex != nil {
+		m.mutex.Lock()
+		defer m.mutex.Unlock()
+	}
+	C.magic_close(m.db)
+	m.db = nil
 }

--- a/magicmime.go
+++ b/magicmime.go
@@ -42,8 +42,8 @@ type MimeDB struct {
 type SyncMode int
 
 const (
-	Synchronized   SyncMode = iota
-	Unsynchronized SyncMode = iota
+	SYNCHRONIZED   SyncMode = iota
+	UNSYNCHRONIZED SyncMode = iota
 )
 
 type Flag int
@@ -144,7 +144,7 @@ func Open(syncMode SyncMode, flags Flag) (*MimeDB, error) {
 		return nil, errors.New(C.GoString(C.magic_error(db)))
 	}
 	var mutex *sync.Mutex
-	if syncMode == Synchronized {
+	if syncMode == SYNCHRONIZED {
 		mutex = &sync.Mutex{}
 	}
 	return &MimeDB{mutex, db}, nil

--- a/magicmime_test.go
+++ b/magicmime_test.go
@@ -23,49 +23,49 @@ import (
 
 // Tests a gif file.
 func TestGifFile(t *testing.T) {
-	testFile(t, Unsynchronized, "./testdata/sample.gif", "image/gif")
-	testFile(t, Synchronized, "./testdata/sample.gif", "image/gif")
+	testFile(t, UNSYNCHRONIZED, "./testdata/sample.gif", "image/gif")
+	testFile(t, SYNCHRONIZED, "./testdata/sample.gif", "image/gif")
 }
 
 // Tests a jpeg file.
 func TestJpegFile(t *testing.T) {
-	testFile(t, Unsynchronized, "./testdata/sample.jpg", "image/jpeg")
-	testFile(t, Synchronized, "./testdata/sample.jpg", "image/jpeg")
+	testFile(t, UNSYNCHRONIZED, "./testdata/sample.jpg", "image/jpeg")
+	testFile(t, SYNCHRONIZED, "./testdata/sample.jpg", "image/jpeg")
 }
 
 // Tests a png file.
 func TestPngFile(t *testing.T) {
-	testFile(t, Unsynchronized, "./testdata/sample.png", "image/png")
-	testFile(t, Synchronized, "./testdata/sample.png", "image/png")
+	testFile(t, UNSYNCHRONIZED, "./testdata/sample.png", "image/png")
+	testFile(t, SYNCHRONIZED, "./testdata/sample.png", "image/png")
 }
 
 // Tests a pdf file.
 func TestPdfFile(t *testing.T) {
-	testFile(t, Unsynchronized, "./testdata/sample.pdf", "application/pdf")
-	testFile(t, Synchronized, "./testdata/sample.pdf", "application/pdf")
+	testFile(t, UNSYNCHRONIZED, "./testdata/sample.pdf", "application/pdf")
+	testFile(t, SYNCHRONIZED, "./testdata/sample.pdf", "application/pdf")
 }
 
 // Tests a plain text file.
 func TestTextFile(t *testing.T) {
-	testFile(t, Unsynchronized, "./testdata/sample.txt", "text/plain")
-	testFile(t, Synchronized, "./testdata/sample.txt", "text/plain")
+	testFile(t, UNSYNCHRONIZED, "./testdata/sample.txt", "text/plain")
+	testFile(t, SYNCHRONIZED, "./testdata/sample.txt", "text/plain")
 }
 
 // Tests a gzipped tar file.
 func TestGzippedTarFile(t *testing.T) {
-	testFile(t, Unsynchronized, "./testdata/sample.tar.gz", "application/x-gzip")
-	testFile(t, Synchronized, "./testdata/sample.tar.gz", "application/x-gzip")
+	testFile(t, UNSYNCHRONIZED, "./testdata/sample.tar.gz", "application/x-gzip")
+	testFile(t, SYNCHRONIZED, "./testdata/sample.tar.gz", "application/x-gzip")
 }
 
 // Tests a zip file.
 func TestZipFile(t *testing.T) {
-	testFile(t, Unsynchronized, "./testdata/sample.zip", "application/zip")
-	testFile(t, Synchronized, "./testdata/sample.zip", "application/zip")
+	testFile(t, UNSYNCHRONIZED, "./testdata/sample.zip", "application/zip")
+	testFile(t, SYNCHRONIZED, "./testdata/sample.zip", "application/zip")
 }
 
 // Tests a gif buffer with synchronized access
-func TestGifBufferSynchronized(t *testing.T) {
-	db, err := Open(Synchronized, MAGIC_MIME_TYPE|MAGIC_SYMLINK|MAGIC_ERROR)
+func TestGifBufferSYNCHRONIZED(t *testing.T) {
+	db, err := Open(SYNCHRONIZED, MAGIC_MIME_TYPE|MAGIC_SYMLINK|MAGIC_ERROR)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,8 +87,8 @@ func TestGifBufferSynchronized(t *testing.T) {
 }
 
 // Tests a gif buffer with unsynchronized access
-func TestGifBufferUnsynchronized(t *testing.T) {
-	db, err := Open(Unsynchronized, MAGIC_MIME_TYPE|MAGIC_SYMLINK|MAGIC_ERROR)
+func TestGifBufferUNSYNCHRONIZED(t *testing.T) {
+	db, err := Open(UNSYNCHRONIZED, MAGIC_MIME_TYPE|MAGIC_SYMLINK|MAGIC_ERROR)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +126,7 @@ func testFile(tb testing.TB, syncMode SyncMode, path string, expected string) {
 }
 
 func TestMissingFile(t *testing.T) {
-	db, err := Open(Unsynchronized, MAGIC_MIME_TYPE|MAGIC_SYMLINK|MAGIC_ERROR)
+	db, err := Open(UNSYNCHRONIZED, MAGIC_MIME_TYPE|MAGIC_SYMLINK|MAGIC_ERROR)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,12 +140,12 @@ func TestMissingFile(t *testing.T) {
 
 func BenchmarkZipFile(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		testFile(b, Unsynchronized, "./testdata/sample.zip", "application/zip")
+		testFile(b, UNSYNCHRONIZED, "./testdata/sample.zip", "application/zip")
 	}
 }
 
-func BenchmarkSynchronizedZipFile(b *testing.B) {
-	db, err := Open(Synchronized, MAGIC_MIME_TYPE|MAGIC_SYMLINK|MAGIC_ERROR)
+func BenchmarkSYNCHRONIZEDZipFile(b *testing.B) {
+	db, err := Open(SYNCHRONIZED, MAGIC_MIME_TYPE|MAGIC_SYMLINK|MAGIC_ERROR)
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
The `magicmime` library uses a global variable to hold the file descriptor associated with the libmagic database.  This is not safe for use across mutliple goroutines.  This pull-request makes it possible to use a `libmagic` file-description in unsynchronized and synchronized modes.

This pull-request changes the `Open` function API signature to add a parameter indicating the synchronization mode (`SYNCHRONIZED` or `UNSYNCHRONIZED`), and returns a pointer to a struct (type `MimeDB`) that keeps a reference to the libmagic file descriptor and mutex (if synchronized).

The `TypeByBuffer`, `TypeByFile`, and `Close` functions are now receiver functions that operate on the new `MimeDB` struct type.  If the `Open` function was called with `SYNCHRONIZED` SyncMode then these functions will use a mutex to coordinate calls to the libmagic library.