### PR TITLE
add windows build option

### DIFF
--- a/magicmime.go
+++ b/magicmime.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build linux darwin
+// +build linux darwin windows
 
 // Package magicmime detects mimetypes using libmagic.
 // This package requires libmagic, install it by the following


### PR DESCRIPTION
I build libmagic easy in msys2 on windows,but must change the "+build" line to build magicmime