### PR TITLE
Handle empty byte slices in TypeByBuffer

### DIFF
--- a/magicmime.go
+++ b/magicmime.go
@@ -158,8 +158,13 @@ func (d *Decoder) TypeByFile(filename string) (string, error) {
 // TypeByBuffer looks up for a blob's mimetype by its contents.
 // It uses a magic number database which is described in magic(5).
 func (d *Decoder) TypeByBuffer(blob []byte) (string, error) {
-	bytes := unsafe.Pointer(&blob[0])
-	out := C.magic_buffer(d.db, bytes, C.size_t(len(blob)))
+	var bytes unsafe.Pointer
+	bloblen := len(blob)
+	if bloblen > 0 {
+		bytes = unsafe.Pointer(&blob[0])
+	}
+
+	out := C.magic_buffer(d.db, bytes, C.size_t(bloblen))
 	if out == nil {
 		return "", errors.New(C.GoString(C.magic_error(d.db)))
 	}

--- a/magicmime_test.go
+++ b/magicmime_test.go
@@ -78,6 +78,23 @@ func TestGifBuffer(t *testing.T) {
 	}
 }
 
+func TestEmptyBuffer(t *testing.T) {
+	if err := Open(MAGIC_MIME_TYPE | MAGIC_SYMLINK | MAGIC_ERROR); err != nil {
+		t.Fatal(err)
+	}
+	defer Close()
+
+	var buffer []byte
+	expected := "application/x-empty"
+	mimetype, err := TypeByBuffer(buffer)
+	if err != nil {
+		panic(err)
+	}
+	if mimetype != expected {
+		t.Errorf("expected %s; got %s.", expected, mimetype)
+	}
+}
+
 func testFile(tb testing.TB, path string, expected string) {
 	if err := Open(MAGIC_MIME_TYPE | MAGIC_SYMLINK | MAGIC_ERROR); err != nil {
 		tb.Fatal(err)


### PR DESCRIPTION
Previously, passing an empty []byte paniced when trying to get a pointer
to the first element. Since the slice is empty, that resulted in a
index out of range runtime error.