### PR TITLE
Add include path fix for M1 Macs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
-  - 1.7.x
-  - 1.8.x
-  - 1.9.x
+  - 1.16.x
+  - 1.17.x
+  - 1.18.x
   - tip
 addons:
   apt:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/rakyll/magicmime
+
+go 1.16

--- a/magicmime.go
+++ b/magicmime.go
@@ -23,7 +23,7 @@
 package magicmime
 
 // #cgo pkg-config: libmagic
-// #cgo CFLAGS: -I/usr/local/include
+// #cgo CFLAGS: -I/usr/local/include -I/opt/homebrew/opt/libmagic/include
 // #include <stdlib.h>
 // #include <magic.h>
 import "C"

--- a/magicmime.go
+++ b/magicmime.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build linux darwin freebsd
+//go:build linux || darwin || freebsd
 
 // Package magicmime detects mimetypes using libmagic.
 // This package requires libmagic, install it by the following

--- a/magicmime.go
+++ b/magicmime.go
@@ -22,8 +22,8 @@
 //	 - Mac OS X: brew install libmagic
 package magicmime
 
+// #cgo pkg-config: libmagic
 // #cgo CFLAGS: -I/usr/local/include
-// #cgo LDFLAGS: -lmagic -L/usr/local/lib
 // #include <stdlib.h>
 // #include <magic.h>
 import "C"


### PR DESCRIPTION
Also:

* Adds a go.mod file
* Uses pkg-config to generate flags
* Updated Go versions for Travis CI